### PR TITLE
Fix useCopilotAction handler re-render bug

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -575,7 +575,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
 export const defaultCopilotContextCategories = ["global"];
 
 function entryPointsToFunctionCallHandler(actions: FrontendAction<any>[]): FunctionCallHandler {
-  return async ({ name, args }: { name: string; args: Record<string, any> }) => {
+  return async ({ name, args, executionId }: { name: string; args: Record<string, any>; executionId?: string }) => {
     let actionsByFunctionName: Record<string, FrontendAction<any>> = {};
     for (let action of actions) {
       actionsByFunctionName[action.name] = action;
@@ -587,7 +587,10 @@ function entryPointsToFunctionCallHandler(actions: FrontendAction<any>[]): Funct
       await new Promise<void>((resolve, reject) => {
         flushSync(async () => {
           try {
-            result = await action.handler?.(args);
+            // Always pass args and optional meta with executionId. For no-args handlers,
+            // extra parameters are ignored at runtime and remain backward compatible.
+            // Using `as any` to avoid complex conditional typing here.
+            result = await (action.handler as any)?.(args, { executionId });
             resolve();
           } catch (error) {
             reject(error);

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -587,10 +587,9 @@ function entryPointsToFunctionCallHandler(actions: FrontendAction<any>[]): Funct
       await new Promise<void>((resolve, reject) => {
         flushSync(async () => {
           try {
-            // Always pass args and optional meta with executionId. For no-args handlers,
-            // extra parameters are ignored at runtime and remain backward compatible.
-            // Using `as any` to avoid complex conditional typing here.
-            result = await (action.handler as any)?.(args, { executionId });
+            // Prefer executionId sourced from the action render (HITL), otherwise from the backend callback meta.
+            const effectiveExecutionId = (action as any)._executionId || executionId;
+            result = await (action.handler as any)?.(args, { executionId: effectiveExecutionId });
             resolve();
           } catch (error) {
             reject(error);

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -1080,7 +1080,6 @@ async function executeAction({
     messages: currentMessagesForHandler,
     name: message.name,
     args: message.arguments,
-    executionId: message.id,
   });
 
   // For HITL actions, call flushSync immediately after their handler has set up the promise

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -1080,6 +1080,7 @@ async function executeAction({
     messages: currentMessagesForHandler,
     name: message.name,
     args: message.arguments,
+    executionId: message.id,
   });
 
   // For HITL actions, call flushSync immediately after their handler has set up the promise

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-action.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-action.ts
@@ -228,24 +228,24 @@ export function useCopilotAction<const T extends Parameter[] | [] = []>(
         // If conditions met, status remains 'executing'
       }
       // Create type safe waitProps based on whether T extends empty array or not
+      const isActiveExecutingInstance =
+        status === "executing" &&
+        renderAndWaitRef.current &&
+        renderAndWaitRef.current.messageId === currentRenderMessageId;
+
+      // Expose the current execution id on the action so the provider can pass it to the handler meta
+      if (isActiveExecutingInstance && currentRenderMessageId) {
+        (action as any)._executionId = currentRenderMessageId;
+      }
+
       const waitProps = {
         status,
         args: props.args,
         result: props.result,
         // handler and respond should only be provided if this is the truly active instance
         // and its promise infrastructure is ready.
-        handler:
-          status === "executing" &&
-          renderAndWaitRef.current &&
-          renderAndWaitRef.current.messageId === currentRenderMessageId
-            ? renderAndWaitRef.current!.resolve
-            : undefined,
-        respond:
-          status === "executing" &&
-          renderAndWaitRef.current &&
-          renderAndWaitRef.current.messageId === currentRenderMessageId
-            ? renderAndWaitRef.current!.resolve
-            : undefined,
+        handler: isActiveExecutingInstance ? renderAndWaitRef.current!.resolve : undefined,
+        respond: isActiveExecutingInstance ? renderAndWaitRef.current!.resolve : undefined,
       } as T extends [] ? ActionRenderPropsNoArgsWait<T> : ActionRenderPropsWait<T>;
 
       // Type guard to check if renderAndWait is for no args case

--- a/CopilotKit/packages/runtime/src/service-adapters/events.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/events.ts
@@ -492,7 +492,8 @@ async function executeAction(
   } else {
     // call the function
     try {
-      const result = await action.handler?.(args);
+      // Pass the executionId so handlers can dedupe across re-renders if needed
+      const result = await (action.handler as any)?.(args, { executionId: actionExecutionId });
       await streamLangChainResponse({
         result,
         eventStream$,

--- a/CopilotKit/packages/shared/src/types/action.ts
+++ b/CopilotKit/packages/shared/src/types/action.ts
@@ -78,13 +78,20 @@ export type MappedParameterTypes<T extends Parameter[] | [] = []> = T extends []
         | BaseParameterType<P>;
     };
 
+export type ActionHandlerMeta = {
+  /** Execution identifier for the current action call */
+  executionId?: string;
+};
+
 export type Action<T extends Parameter[] | [] = []> = {
   name: string;
   description?: string;
   parameters?: T;
   handler?: T extends []
-    ? () => any | Promise<any>
-    : (args: MappedParameterTypes<T>) => any | Promise<any>;
+    ? // No-args handlers remain callable without parameters for backward compatibility,
+      // but may optionally receive a metadata object containing the executionId.
+      ((meta?: ActionHandlerMeta) => any | Promise<any>) | (() => any | Promise<any>)
+    : (args: MappedParameterTypes<T>, meta?: ActionHandlerMeta) => any | Promise<any>;
 };
 
 // This is the original "ceiling is being raised" version of MappedParameterTypes.

--- a/CopilotKit/packages/shared/src/types/openai-assistant.ts
+++ b/CopilotKit/packages/shared/src/types/openai-assistant.ts
@@ -30,6 +30,8 @@ export interface FunctionCallHandlerArguments {
   messages: any[];
   name: string;
   args: any;
+  /** Optional execution identifier for this function/action call, useful for deduping */
+  executionId?: string;
 }
 
 export type FunctionCallHandler = (args: FunctionCallHandlerArguments) => Promise<any>;

--- a/docs/content/docs/reference/hooks/useCopilotAction.mdx
+++ b/docs/content/docs/reference/hooks/useCopilotAction.mdx
@@ -71,8 +71,8 @@ This hooks enables you to dynamically generate UI elements and render them in th
       The name of the action.
     </PropertyReference>
 
-    <PropertyReference name="handler" type="(args) => Promise<any>" required>
-      The handler of the action.
+    <PropertyReference name="handler" type="(args, meta?) => Promise<any>" required>
+      The handler of the action. An optional <code>meta</code> object is provided containing <code>executionId</code> to help you dedupe executions across re-renders.
     </PropertyReference>
 
     <PropertyReference name="description" type="string">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses a bug where `useCopilotAction` handlers could trigger multiple times during re-renders. To prevent this, an `executionId` is now passed to the action handler, allowing for deduplication of executions.

Changes include:
- Updating `FunctionCallHandlerArguments` and `Action.handler` types to include an optional `executionId` in a `meta` object, maintaining backward compatibility.
- Propagating the `executionId` from the action execution message through `use-chat`, `CopilotKitInternal` (provider), and the runtime service adapter to both frontend and backend action handlers.
- Updating the `useCopilotAction` documentation to reflect the new `handler(args, meta?)` signature and the availability of `meta.executionId`.

## Related PRs and Issues

N/A

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

---
<a href="https://cursor.com/background-agent?bcId=bc-a57e7aec-068d-4717-937d-9ef2d61beffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a57e7aec-068d-4717-937d-9ef2d61beffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

